### PR TITLE
enhancement on importSVG

### DIFF
--- a/raphael-svg-import.js
+++ b/raphael-svg-import.js
@@ -1,23 +1,25 @@
 /*
  * Raphael SVG Import 0.0.1 - Extension to Raphael JS
  *
- * Copyright (c) 2009 Wout Fierens
+ * Copyright (c) 2009 Wout Fierens; Georgi Momchilov 2011
  * Licensed under the MIT (http://www.opensource.org/licenses/mit-license.php) license.
  */
 Raphael.fn.importSVG = function (raw_svg) {
   try {
-    if (raw_svg.blank())
+    if (raw_svg.blank()){
       throw "No data was provided.";
+    }
     raw_svg = raw_svg.gsub(/\n|\r|\t/, '');
-    if (!raw_svg.match(/<svg(.*?)>(.*)<\/svg>/i))
+    if (!raw_svg.match(/<svg(.*?)>(.*)<\/svg>/i)){
       throw "The data you entered doesn't contain SVG.";
-    $w("rect polyline circle ellipse path polygon image text").each((function(node) {
-      raw_svg.scan(new RegExp("<" + node + "(.*?)\/>"), (function(match) {
-        var attr = { "stroke-width": 0, "fill":"#fff" };
+    }
+    raw_svg.scan(/<(rect|polyline|circle|ellipse|path|polygon|image|text)(.*?)\/>/, (function(match) {
+        var attr = { "stroke-width": 0, "fill":"#000" };
         var shape;
-        if (match && match[1]) {
-          var style;
-          match[1].scan(/([a-z\-]+)="(.*?)"/, function(m) {
+        if (match && match[2]) {
+          var node = match[1],
+              style;
+          match[2].scan(/([a-z\-]+)="(.*?)"/, function(m) {
             switch(m[1]) {
               case "stroke-dasharray":
                 attr[m[1]] = "- ";
@@ -60,7 +62,6 @@ Raphael.fn.importSVG = function (raw_svg) {
           //-F break;
         }
         shape.attr(attr);
-      }).bind(this));
     }).bind(this));
   } catch (error) {
     alert("The SVG data you entered was invalid! (" + error + ")");


### PR DESCRIPTION
Hello there,

I've added a small enhancement to the plugin - it now goes through the elements in their respective order in the SVG document instead of their order in the "shapes" array. 

Example: If you have shapes in the following order: rectangle, circle, rectangle the old version would first draw the two rectangles and then the circle and their respective 'z-index' would be wrong - the circle would be on top of both rectangles while it should be above the first and below the second. This small adjustment fixes that.

regards,
Georgi
