### PR TITLE
Polygon Path Building Bugfix

### DIFF
--- a/raphael-svg-import.js
+++ b/raphael-svg-import.js
@@ -89,7 +89,7 @@ Raphael.fn.polygon = function(pointString) {
      var c = point[i].split(',');
      for(var j=0; j < c.length; j++) {
         var d = parseFloat(c[j]);
-        if (d)
+        if (!isNaN(d))
           poly.push(d);
      };
      if (i == 0)


### PR DESCRIPTION
Fixed a bug in polygon parsing where a zero path value was not being rendered because 0 is not truthy in javascript. Changed the check to use `isNaN()`.
