### PR TITLE
Modified line 92 to accept points situated at x=0 or y=0.

### DIFF
--- a/raphael-svg-import.js
+++ b/raphael-svg-import.js
@@ -89,7 +89,7 @@ Raphael.fn.polygon = function(pointString) {
      var c = point[i].split(',');
      for(var j=0; j < c.length; j++) {
         var d = parseFloat(c[j]);
-        if (d)
+        if (d || d==0)
           poly.push(d);
      };
      if (i == 0)


### PR DESCRIPTION
Slight bug on line 92, preventing polygons from having a coordinate with either x=0, or y=0.
